### PR TITLE
Update snippets.md

### DIFF
--- a/snippets.md
+++ b/snippets.md
@@ -42,3 +42,4 @@ Vue가 포함된 [JsFiddle](https://jsfiddle.net/changjoo_park/bs3Lx0Lq/)에서 
 - [inheritAttrs, $attrs, $listeners 예제 (2.4.0+)](https://jsfiddle.net/changjoo_park/pzx08wp9/) - [@changjoo-park](https://github.com/ChangJoo-Park/)
 - [input 엘리먼트에서 동적 type 바인딩 2.5.0+](https://jsfiddle.net/changjoo_park/Lrngohoo/) - [@changjoo-park](https://github.com/ChangJoo-Park/)
 - [Event Handling `.exact` 예제 2.5.0+](https://jsfiddle.net/changjoo_park/sgkacLgL/) - [@changjoo-park](https://github.com/ChangJoo-Park/)
+- [vue-router lazy loading](https://jsfiddle.net/gongzza/qgujfsy0/) - [@gongzza](https://github.com/gongzza/)


### PR DESCRIPTION
vue-router lazy loading 예제를 추가하였습니다.

vue-router navigation guards를 이용해서 비동기 페이지 컴포넌트를 로딩할 때 로딩바를 보여주는 예제입니다.